### PR TITLE
Add auto embed of the inline player

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,15 +17,16 @@ chrome.extension.onMessage.addListener(
         return true;
     } else if (request.name == "getOptions") {
         var defaults = {
-            "textlinks":        1,
-            "imglinks":         0,
-            "embed":            1,
-            "embedleft":        0,
-            "replacename":      1,
-            "tooltip":          1,
-            "timestamp":        0,
-            "timestamptooltip": 1,
-            "restrictedicon":   1,
+            "textlinks":            1,
+            "imglinks":             0,
+            "embed":                1,
+            "embedleft":            0,
+            "showEmbeddedPlayer":   0,
+            "replacename":          1,
+            "tooltip":              1,
+            "timestamp":            0,
+            "timestamptooltip":     1,
+            "restrictedicon":       1,
         };
 
         var resp = {};

--- a/options.html
+++ b/options.html
@@ -96,6 +96,19 @@
         <li>
           <div>
             <div class="label">
+              <span>Show inline embedded player automatically</span>
+            </div>
+            
+            <div class="slideThree">  
+              <input type="checkbox" id="showEmbeddedPlayer" name="showEmbeddedPlayer" />
+              <label for="showEmbeddedPlayer"></label>
+            </div>
+          </div>
+        </li>
+
+        <li>
+          <div>
+            <div class="label">
               <span>Show tooltip with information when hovering over YouTube links:</span>
             </div>
             

--- a/script.js
+++ b/script.js
@@ -31,6 +31,7 @@ $(document).ready(function () {
         YTTA.timestamptooltip = resp["timestamptooltip"]*1;
         YTTA.restrictedicon = resp["restrictedicon"]*1;
         YTTA.embedleft = resp["embedleft"]*1;
+        YTTA.showEmbeddedPlayer = resp["showEmbeddedPlayer"]*1;
 
         var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
         var observer = new MutationObserver( function (mutations) {
@@ -112,7 +113,7 @@ function addTitle(resp) {
             var embedhtml = '<img src="' + YTTA.EMBED_IMG + '" ' +
                             'class="' + YTTA.CLASS_EMBED_ICON + '" ' +
                             'title="Click to play video inline." />' +
-                            '<div class="' + YTTA.CLASS_EMBED_DISABLED + '">' +
+                            '<div class="' + (YTTA.showEmbeddedPlayer ? YTTA.CLASS_EMBED_ENABLED : YTTA.CLASS_EMBED_DISABLED) + '">' +
                             embed +
                             '</div>';
             var embedimg;


### PR DESCRIPTION
## Proposed Changes

1. Add an entry to the options so that a user can enable/disable this feature (it will be disabled by default)
2. Run the required code if the option is enabled to show the inline embedded player (will re-use the code that has been added to show/hide the player already)
